### PR TITLE
Simplify changelog script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "release": "release-it",
-    "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -n .conventional-changelog.mjs -s -r 0 --skip-unstable"
+    "changelog": "repo-toolkit-changelog"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- replace the package changelog script with the repo toolkit changelog command
- remove the unused release script from package.json

## Details
This change updates the root package scripts to use the shared `repo-toolkit-changelog` command for changelog generation and drops the old `release-it` script entry, which is no longer needed in this workspace.

## Files changed
- `package.json`