### PR TITLE
Improve release and publish workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,4 +35,4 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-        trivy: true
+        trivy: false

--- a/.github/workflows/release-tag-changelog.yml
+++ b/.github/workflows/release-tag-changelog.yml
@@ -37,3 +37,9 @@ jobs:
       with:
         tag: ${{ github.event.inputs.tag }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        auto-merge-pr: 'true'
+        delete-merged-branch: 'true'
+        sign-commit: 'true'
+        gpg-private-key: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+        gpg-passphrase: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+        git-user-email: ${{ secrets.RELEASE_USER_EMAIL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,14 @@ jobs:
         make build-all VERSION=${{ github.ref_name}}
         make build-archive
 
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: database-tools-${{ github.ref_name }}
+        path: dist/*.tar.gz
+
     - name: Release
       uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
       with:
+        generate_release_notes: true
         files: dist/*.tar.gz


### PR DESCRIPTION
## Summary

This change set updates the GitHub Actions release pipeline to better support automated releases and published artifacts.

## Changes

- Disable Trivy scanning in the publish workflow.
- Extend the release tag changelog workflow to:
  - auto-merge the generated pull request
  - delete the merged branch
  - sign the commit
  - use GPG signing credentials and release author information from secrets
- Update the release workflow to:
  - upload built tarball artifacts
  - generate GitHub release notes automatically

## Notes

These updates are focused on improving release automation and ensuring published release assets and metadata are produced consistently.